### PR TITLE
Fixed file splitting

### DIFF
--- a/misc/upload-git
+++ b/misc/upload-git
@@ -45,16 +45,9 @@ prepare() {
   cp --reflink=auto "$LACELLS_DIR"/lacells-* "$LACELLS_GIT_DIR/"
 
   # Github doesn't like big files, split them.
-  # TODO use find-command instead of harded list here
-  splitcsv "$LACELLS_GIT_DIR/lacells-mcc_208"
-  splitcsv "$LACELLS_GIT_DIR/lacells-mcc_234"
-  splitcsv "$LACELLS_GIT_DIR/lacells-mcc_250"
-  splitcsv "$LACELLS_GIT_DIR/lacells-mcc_262"
-  splitcsv "$LACELLS_GIT_DIR/lacells-mcc_310"
-  splitcsv "$LACELLS_GIT_DIR/lacells-mcc_404"
-  splitcsv "$LACELLS_GIT_DIR/lacells-mcc_440"
-  splitcsv "$LACELLS_GIT_DIR/lacells-mcc_724"
-
+  for F in $(find "$LACELLS_GIT_DIR" -type f -size +49999999c -name "lacells-mcc_???.csv" ); do
+     splitcsv "${F%.*}"
+  done
   # Add filenames to lacells-countries.csv
   addfilescsv "$LACELLS_GIT_DIR" "lacells-countries.csv" "lacells-mcc_"
 

--- a/misc/upload-git
+++ b/misc/upload-git
@@ -42,7 +42,7 @@ checkgit() {
 prepare() {
   # Update data files
   rm -f "$LACELLS_GIT_DIR/lacells-*"
-  cp "$LACELLS_DIR"/lacells-* "$LACELLS_GIT_DIR/"
+  cp --reflink=auto "$LACELLS_DIR"/lacells-* "$LACELLS_GIT_DIR/"
 
   # Github doesn't like big files, split them.
   # TODO use find-command instead of harded list here
@@ -59,7 +59,7 @@ prepare() {
   addfilescsv "$LACELLS_GIT_DIR" "lacells-countries.csv" "lacells-mcc_"
 
   # Add website files
-  cp "$PREFIX"/misc/html/* "$LACELLS_GIT_DIR/"
+  cp --reflink=auto "$PREFIX"/misc/html/* "$LACELLS_GIT_DIR/"
 }
 
 # Commit and push changes


### PR DESCRIPTION
The database has grown substantially and more files need to be split to stay below the github 50M file size limit.
Also added --reflink=auto to cp command for more efficient file storage when a compatible filesystem like btrfs is used.